### PR TITLE
Bugfix commitlog concurrent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: go
 go:
-  - 1.8.x
   - 1.9.x
+  - 1.10.x
 env:
   - GOARCH=amd64 TEST_RACE=false
   - GOARCH=amd64 TEST_RACE=true

--- a/apps/nsqd/nsqd.go
+++ b/apps/nsqd/nsqd.go
@@ -165,6 +165,8 @@ func nsqdFlagSet(opts *nsqd.Options) *flag.FlagSet {
 	flagSet.Int("queue-scan-worker-pool-max", opts.QueueScanWorkerPoolMax, "the max scan worker pool")
 	flagSet.Float64("queue-scan-dirty-percent", opts.QueueScanDirtyPercent, "retry scan immediately if dirty percent happened in last scan")
 	flagSet.Bool("allow-zan-test-skip", opts.AllowZanTestSkip, "allow zan test message filter in new created channel & channels under newly upgraded topic")
+	flagSet.Int("default-commit-buf", int(opts.DefaultCommitBuf), "the default commit buffer for topic data")
+	flagSet.Int("max-commit-buf", int(opts.MaxCommitBuf), "the max commit buffer for topic data")
 	return flagSet
 }
 

--- a/consistence/commitlog.go
+++ b/consistence/commitlog.go
@@ -15,10 +15,11 @@ import (
 )
 
 const (
-	DEFAULT_COMMIT_BUF_SIZE = 400
-	MAX_COMMIT_BUF_SIZE     = 1000
-	MAX_INCR_ID_BIT         = 50
+	MAX_INCR_ID_BIT = 50
 )
+
+var DEFAULT_COMMIT_BUF_SIZE = 400
+var MAX_COMMIT_BUF_SIZE = 1000
 
 var (
 	ErrCommitLogWrongID              = errors.New("commit log id is wrong")

--- a/consistence/data_placement_mgr.go
+++ b/consistence/data_placement_mgr.go
@@ -128,6 +128,11 @@ func (h *IntHeap) Pop() interface{} {
 	return x
 }
 
+type WrapChannelConsumerOffset struct {
+	Name string
+	ChannelConsumerOffset
+}
+
 type NodeTopicStats struct {
 	NodeID string
 	// the data (MB) need to be consumed on the leader for all channels in the topic.
@@ -142,6 +147,7 @@ type NodeTopicStats struct {
 	ChannelNum             map[string]int
 	ChannelList            map[string][]string
 	ChannelMetas           map[string][]nsqd.ChannelMetaInfo
+	ChannelOffsets         map[string][]WrapChannelConsumerOffset
 }
 
 func NewNodeTopicStats(nid string, cap int, cpus int) *NodeTopicStats {
@@ -154,6 +160,7 @@ func NewNodeTopicStats(nid string, cap int, cpus int) *NodeTopicStats {
 		ChannelNum:             make(map[string]int, cap),
 		ChannelList:            make(map[string][]string),
 		ChannelMetas:           make(map[string][]nsqd.ChannelMetaInfo),
+		ChannelOffsets:         make(map[string][]WrapChannelConsumerOffset),
 		NodeCPUs:               cpus,
 	}
 }

--- a/consistence/etcd_client.go
+++ b/consistence/etcd_client.go
@@ -33,6 +33,15 @@ func NewEClient(host string) (*EtcdClient, error) {
 	}, nil
 }
 
+func (self *EtcdClient) GetNewest(key string, sort, recursive bool) (*client.Response, error) {
+	getOptions := &client.GetOptions{
+		Recursive: recursive,
+		Sort:      sort,
+		Quorum:    true,
+	}
+	return self.kapi.Get(context.Background(), key, getOptions)
+}
+
 func (self *EtcdClient) Get(key string, sort, recursive bool) (*client.Response, error) {
 	getOptions := &client.GetOptions{
 		Recursive: recursive,

--- a/consistence/nsqd_coordinator.go
+++ b/consistence/nsqd_coordinator.go
@@ -35,6 +35,8 @@ var (
 	MaxTopicRetentionSizePerDay = int64(1024 * 1024 * 1024 * 16)
 )
 
+var testCatchupPausedPullLogs int32
+
 func GetTopicPartitionFileName(topic string, partition int, suffix string) string {
 	var tmpbuf bytes.Buffer
 	tmpbuf.WriteString(topic)
@@ -1644,6 +1646,7 @@ func (self *NsqdCoordinator) pullCatchupDataFromLeader(tc *TopicCoordinator,
 		if tc.IsExiting() {
 			// the topic coordinator can be notified to close while catchup if other isr node is already joined.
 			// mostly happened while restarting some node.
+			coordLog.Infof("topic %v is exiting while pulling logs ", topicInfo.GetTopicDesp())
 			return ErrTopicExiting
 		}
 		countNumIndex, localErr := logMgr.ConvertToCountIndex(logIndex, offset)
@@ -1697,6 +1700,13 @@ func (self *NsqdCoordinator) pullCatchupDataFromLeader(tc *TopicCoordinator,
 			}
 			lastCommitOffset = queueEnd
 
+			for {
+				if atomic.LoadInt32(&testCatchupPausedPullLogs) == 1 {
+					time.Sleep(time.Second * 2)
+				} else {
+					break
+				}
+			}
 			localErr = logMgr.AppendCommitLog(&l, true)
 			if localErr != nil {
 				coordLog.Errorf("Failed to append local log: %v, need to be fixed ", localErr)
@@ -1827,15 +1837,16 @@ func (self *NsqdCoordinator) catchupFromLeader(topicInfo TopicPartitionMetaInfo,
 	tc.GetData().updateBufferSize(int(dyConf.SyncEvery - 1))
 	localTopic.SetDynamicInfo(*dyConf, tc.GetData().logMgr)
 
-	syncErr := self.pullCatchupDataFromLeader(tc, topicInfo, localTopic, tc.GetData().logMgr, false, logIndex, offset)
-	if syncErr != nil {
-		coordLog.Infof("pull topic %v catchup data failed:%v", topicInfo.GetTopicDesp(), syncErr)
-		if joinISRSession == "" && strings.Contains(syncErr.ErrMsg, nsqd.ErrMoveOffsetOverflowed.Error()) {
+	coordErr = self.pullCatchupDataFromLeader(tc, topicInfo, localTopic, tc.GetData().logMgr, false, logIndex, offset)
+	if coordErr != nil {
+		coordLog.Infof("pull topic %v catchup data failed:%v", topicInfo.GetTopicDesp(), coordErr)
+		if joinISRSession == "" && strings.Contains(coordErr.ErrMsg, nsqd.ErrMoveOffsetOverflowed.Error()) {
 			// while join session is empty, it may happen the leader is writing while catchup
 			// so we may get the unflushed commit log, which will return overflow error.
 			// we can ignore this and continue catchup the left data after we disabled write on leader
+			coordErr = nil
 		} else {
-			return syncErr
+			return coordErr
 		}
 	}
 
@@ -1850,23 +1861,24 @@ func (self *NsqdCoordinator) catchupFromLeader(topicInfo TopicPartitionMetaInfo,
 			}
 			// ignore error if delayed queue is not enabled
 		} else {
-			syncErr = self.pullCatchupDataFromLeader(tc, topicInfo, localTopic, tc.GetData().delayedLogMgr, true, logIndex, offset)
-			if syncErr != nil {
+			coordErr = self.pullCatchupDataFromLeader(tc, topicInfo, localTopic, tc.GetData().delayedLogMgr, true, logIndex, offset)
+			if coordErr == nil && needFullSync {
+				coordErr = self.pullDelayedQueueFromLeader(tc, topicInfo, localTopic, c)
+			}
+			if coordErr != nil {
 				if atomic.LoadInt32(&nsqd.EnableDelayedQueue) == 1 {
-					coordLog.Warningf("pull topic %v catchup delayed queue data error:%v", topicInfo.GetTopicDesp(), syncErr)
-					return syncErr
+					coordLog.Warningf("pull topic %v catchup delayed queue data error:%v", topicInfo.GetTopicDesp(), coordErr)
+					return coordErr
 				}
-				coordLog.Infof("ignore the failed since not enabled, pull topic %v catchup delayed queue data error:%v", topicInfo.GetTopicDesp(), syncErr)
-			} else if needFullSync {
-				syncErr = self.pullDelayedQueueFromLeader(tc, topicInfo, localTopic, c)
-				if syncErr != nil {
-					coordLog.Infof("pull topic %v catchup delayed queue data failed:%v", topicInfo.GetTopicDesp(), syncErr)
-					if atomic.LoadInt32(&nsqd.EnableDelayedQueue) == 1 {
-						return syncErr
-					}
-				}
+				coordLog.Infof("ignore the failed since not enabled, pull topic %v catchup delayed queue data error:%v", topicInfo.GetTopicDesp(), coordErr)
+				coordErr = nil
 			}
 		}
+	}
+	coordErr = self.syncChannelsFromOther(c, topicInfo, localTopic)
+	if coordErr != nil {
+		coordLog.Infof("local topic %v sync channels failed: %v while joining isr", topicInfo.GetTopicDesp(), coordErr.String())
+		return coordErr
 	}
 
 	if joinISRSession == "" {
@@ -1874,55 +1886,6 @@ func (self *NsqdCoordinator) catchupFromLeader(topicInfo TopicPartitionMetaInfo,
 		// if success, the topic leader will disable new write.
 		coordLog.Infof("I am requesting join isr: %v on topic: %v",
 			self.myNode.GetID(), topicInfo.Name)
-		stat, err := c.GetTopicStats(topicInfo.Name)
-		if err != nil {
-			coordLog.Infof("try get stats from leader failed: %v", err)
-		} else {
-			// sync the history stats to make sure balance stats data is ok
-			// sync channels from leader
-			localTopic.GetDetailStats().ResetHistoryInitPub(localTopic.TotalDataSize())
-			localTopic.GetDetailStats().UpdateHistory(stat.TopicHourlyPubDataList[topicInfo.GetTopicDesp()])
-			chList, ok := stat.ChannelList[topicInfo.GetTopicDesp()]
-			coordLog.Infof("topic %v sync channel list from leader: %v", topicInfo.GetTopicDesp(), chList)
-			//TODO: channel confirmed offset must be synced from leader
-			// if not, when new topic migrated to this node, channel depth=0 for new channel
-			// and then leader changed to this topic, then the channel confirmed offset
-			// will be skip to the end on the new topic node.
-			if ok && len(chList) > 0 {
-				chMetas, _ := stat.ChannelMetas[topicInfo.GetTopicDesp()]
-				metaMaps := make(map[string]nsqd.ChannelMetaInfo, len(chMetas))
-				for _, meta := range chMetas {
-					metaMaps[meta.Name] = meta
-				}
-
-				oldChList := localTopic.GetChannelMapCopy()
-				for _, chName := range chList {
-					if protocol.IsEphemeral(chName) {
-						continue
-					}
-					ch := localTopic.GetChannel(chName)
-					if meta, ok := metaMaps[chName]; ok {
-						if meta.Paused {
-							ch.Pause()
-						}
-						if meta.Skipped {
-							ch.Skip()
-						}
-						if meta.IsZanTestSkipepd() {
-							ch.SkipZanTest()
-						}
-					}
-					delete(oldChList, chName)
-				}
-				if len(oldChList) > 0 {
-					coordLog.Infof("topic %v local channel not on leader: %v", topicInfo.GetTopicDesp(), oldChList)
-					for chName := range oldChList {
-						localTopic.CloseExistingChannel(chName, false)
-					}
-				}
-				localTopic.SaveChannelMeta()
-			}
-		}
 		if !tc.IsExiting() {
 			go func() {
 				err := self.requestJoinTopicISR(&topicInfo)
@@ -1934,7 +1897,6 @@ func (self *NsqdCoordinator) catchupFromLeader(topicInfo TopicPartitionMetaInfo,
 	} else if joinISRSession != "" {
 		// with join isr session, it means the leader write is disabled and waiting the catchup join isr.
 		// so we notify leader we are ready join isr safely.
-		localTopic.ForceFlush()
 		tc.GetData().flushCommitLogs()
 		tc.GetData().switchForMaster(false)
 
@@ -1951,6 +1913,93 @@ func (self *NsqdCoordinator) catchupFromLeader(topicInfo TopicPartitionMetaInfo,
 	}
 
 	coordLog.Infof("local topic catchup done: %v", topicInfo.GetTopicDesp())
+	return nil
+}
+
+func (self *NsqdCoordinator) syncChannelsFromOther(c *NsqdRpcClient, topicInfo TopicPartitionMetaInfo, localTopic *nsqd.Topic) *CoordErr {
+	stat, err := c.GetTopicStats(topicInfo.Name)
+	if err != nil {
+		coordLog.Infof("topic %v try get stats from other %v failed: %v", topicInfo.GetTopicDesp(), c.remote, err)
+		return NewCoordErr(err.Error(), CoordNetErr)
+	} else {
+		// sync the history stats to make sure balance stats data is ok
+		// sync channels from leader
+		localTopic.GetDetailStats().ResetHistoryInitPub(localTopic.TotalDataSize())
+		localTopic.GetDetailStats().UpdateHistory(stat.TopicHourlyPubDataList[topicInfo.GetTopicDesp()])
+
+		chList, ok := stat.ChannelList[topicInfo.GetTopicDesp()]
+		coordLog.Infof("topic %v sync channel list from leader: %v", topicInfo.GetTopicDesp(), chList)
+		//TODO: channel confirmed offset must be synced from leader
+		// if not, when new topic migrated to this node, channel depth=0 for new channel
+		// and then leader changed to this topic, then the channel confirmed offset
+		// will be skip to the end on the new topic node.
+		if ok && len(chList) > 0 {
+			metaMaps := make(map[string]nsqd.ChannelMetaInfo)
+			consumerOffsetMap := make(map[string]WrapChannelConsumerOffset)
+			if len(stat.ChannelMetas) > 0 {
+				chMetas, _ := stat.ChannelMetas[topicInfo.GetTopicDesp()]
+				for _, meta := range chMetas {
+					metaMaps[meta.Name] = meta
+				}
+			}
+			if len(stat.ChannelOffsets) > 0 {
+				chConsumerOffsets, _ := stat.ChannelOffsets[topicInfo.GetTopicDesp()]
+				for _, offset := range chConsumerOffsets {
+					consumerOffsetMap[offset.Name] = offset
+				}
+			}
+
+			oldChList := localTopic.GetChannelMapCopy()
+			for _, chName := range chList {
+				if protocol.IsEphemeral(chName) {
+					continue
+				}
+				ch := localTopic.GetChannel(chName)
+				if meta, ok := metaMaps[chName]; ok {
+					if meta.Paused {
+						ch.Pause()
+					}
+					if meta.Skipped {
+						ch.Skip()
+					}
+					if meta.IsZanTestSkipepd() {
+						ch.SkipZanTest()
+					}
+				}
+				if offset, ok := consumerOffsetMap[chName]; ok {
+					offset.AllowBackward = true
+					currentEnd := ch.GetChannelEnd()
+					if nsqd.BackendOffset(offset.VOffset) > currentEnd.Offset() {
+						offset.VOffset = int64(currentEnd.Offset())
+						offset.VCnt = currentEnd.TotalMsgCnt()
+					}
+					if offset.NeedUpdateConfirmed {
+						ch.UpdateConfirmedInterval(offset.ConfirmedInterval)
+					}
+					coordLog.Infof("topic %v local channel(%v) sync confirmed to offset %v, current end: %v",
+						topicInfo.GetTopicDesp(), chName, offset, currentEnd)
+					err := ch.ConfirmBackendQueueOnSlave(nsqd.BackendOffset(offset.VOffset), offset.VCnt, offset.AllowBackward)
+					if err != nil {
+						coordLog.Warningf("topic %v update local channel(%v) offset %v failed: %v, current channel end: %v, topic end: %v",
+							topicInfo.GetTopicDesp(), chName, offset, err, currentEnd, localTopic.TotalDataSize())
+						if err == nsqd.ErrExiting {
+							return &CoordErr{err.Error(), RpcNoErr, CoordTmpErr}
+						}
+						return &CoordErr{err.Error(), RpcCommonErr, CoordSlaveErr}
+					}
+				}
+				delete(oldChList, chName)
+			}
+			if len(oldChList) > 0 {
+				coordLog.Infof("topic %v local channel not on leader: %v", topicInfo.GetTopicDesp(), oldChList)
+				for chName := range oldChList {
+					localTopic.CloseExistingChannel(chName, false)
+				}
+			}
+			localTopic.SaveChannelMeta()
+			localTopic.ForceFlush()
+		}
+	}
 	return nil
 }
 
@@ -2425,7 +2474,14 @@ func (self *NsqdCoordinator) trySyncTopicChannels(tcData *coordData, syncDelayed
 				syncOffset.NeedUpdateConfirmed = true
 			}
 
-			for _, nodeID := range tcData.topicInfo.ISR {
+			nids := make([]string, 0, len(tcData.topicInfo.ISR)+len(tcData.topicInfo.CatchupList))
+			// TODO: Because the new channel on slave will init consume offset to the end of topic,
+			// we should update consume offset to both isr and catchup to avoid skip some messages on the new channel on the slave
+			// if the slave became the new leader.
+			// But the catchup node may fail to connect, so we should avoid block by catchup nodes.
+			nids = append(nids, tcData.topicInfo.ISR...)
+			nids = append(nids, tcData.topicInfo.CatchupList...)
+			for _, nodeID := range nids {
 				if nodeID == self.myNode.GetID() {
 					continue
 				}
@@ -2435,7 +2491,7 @@ func (self *NsqdCoordinator) trySyncTopicChannels(tcData *coordData, syncDelayed
 				}
 				rpcErr = c.UpdateChannelOffset(&tcData.topicLeaderSession, &tcData.topicInfo, ch.GetName(), syncOffset)
 				if rpcErr != nil {
-					coordLog.Infof("node %v update channel %v offset failed %v.", nodeID, ch.GetName(), rpcErr)
+					coordLog.Debugf("node %v update channel %v offset failed %v.", nodeID, ch.GetName(), rpcErr)
 				}
 			}
 			// only the first channel of topic should flush.

--- a/consistence/nsqd_coordinator_test.go
+++ b/consistence/nsqd_coordinator_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -276,7 +277,7 @@ func TestNsqdCoordStartup(t *testing.T) {
 	partition := 1
 
 	if testing.Verbose() {
-		SetCoordLogger(&levellogger.SimpleLogger{}, levellogger.LOG_DETAIL)
+		SetCoordLogger(newTestLogger(t), levellogger.LOG_DETAIL)
 		glog.SetFlags(0, "", "", true, true, 1)
 		glog.StartWorker(time.Second)
 	} else {
@@ -390,7 +391,7 @@ func TestNsqdCoordLeaveFromISR(t *testing.T) {
 	topic := "coordTestTopic"
 	partition := 1
 	if testing.Verbose() {
-		SetCoordLogger(&levellogger.SimpleLogger{}, levellogger.LOG_DETAIL)
+		SetCoordLogger(newTestLogger(t), levellogger.LOG_DETAIL)
 		glog.SetFlags(0, "", "", true, true, 1)
 		glog.StartWorker(time.Second)
 	} else {
@@ -523,7 +524,7 @@ func testNsqdCoordCatchup(t *testing.T, meta TopicMetaInfo, testUpgrade bool, te
 	topic := "coordTestTopic"
 	partition := 1
 	if testing.Verbose() {
-		SetCoordLogger(&levellogger.SimpleLogger{}, levellogger.LOG_DETAIL)
+		SetCoordLogger(newTestLogger(t), levellogger.LOG_DETAIL)
 		glog.SetFlags(0, "", "", true, true, 1)
 		glog.StartWorker(time.Second)
 	} else {
@@ -916,7 +917,146 @@ func TestNsqdCoordCatchupAbort(t *testing.T) {
 	// TODO: test two node catchup and one node is slow catchup,
 	// while the fast node already join the isr, the slow catchup will be notified to abort current catchup
 	// test the abortion while pulling logs (writing commit log)
+	topic := "coordTestTopicAbort"
+	partition := 1
+	if testing.Verbose() {
+		//SetCoordLogger(&levellogger.SimpleLogger{}, levellogger.LOG_DETAIL)
+		SetCoordLogger(newTestLogger(t), levellogger.LOG_DETAIL)
+		glog.SetFlags(0, "", "", true, true, 1)
+		glog.StartWorker(time.Second)
+	} else {
+		SetCoordLogger(newTestLogger(t), levellogger.LOG_DEBUG)
+	}
 
+	nsqd1, randPort1, nodeInfo1, data1 := newNsqdNode(t, "id1")
+	nsqd2, randPort2, nodeInfo2, data2 := newNsqdNode(t, "id2")
+	nsqd3, randPort3, nodeInfo3, data3 := newNsqdNode(t, "id3")
+	meta := TopicMetaInfo{
+		Replica:      2,
+		PartitionNum: 1,
+	}
+	fakeLeadership := NewFakeNSQDLeadership().(*fakeNsqdLeadership)
+	fakeReplicaInfo := &TopicPartitionReplicaInfo{
+		Leader:        nodeInfo1.GetID(),
+		ISR:           make([]string, 0),
+		CatchupList:   make([]string, 0),
+		Epoch:         1,
+		EpochForWrite: 1,
+	}
+	fakeInfo := &TopicPartitionMetaInfo{
+		Name:                      topic,
+		Partition:                 partition,
+		TopicMetaInfo:             meta,
+		TopicPartitionReplicaInfo: *fakeReplicaInfo,
+	}
+
+	fakeInfo.ISR = append(fakeInfo.ISR, nodeInfo1.GetID())
+	fakeInfo.ISR = append(fakeInfo.ISR, nodeInfo2.GetID())
+	fakeInfo.CatchupList = append(fakeInfo.CatchupList, nodeInfo3.GetID())
+
+	tmp := make(map[int]*TopicPartitionMetaInfo)
+	fakeLeadership.UpdateTopics(topic, tmp)
+	fakeLeadership.AcquireTopicLeader(topic, partition, nodeInfo1, fakeInfo.Epoch)
+	tmp[partition] = fakeInfo
+
+	fakeLookupProxy, _ := NewFakeLookupRemoteProxy("127.0.0.1", 0)
+	fakeSession, _ := fakeLeadership.GetTopicLeaderSession(topic, partition)
+	fakeLookupProxy.(*fakeLookupRemoteProxy).leaderSessions[topic] = make(map[int]*TopicLeaderSession)
+	fakeLookupProxy.(*fakeLookupRemoteProxy).leaderSessions[topic][partition] = fakeSession
+
+	nsqdCoord1 := startNsqdCoordWithFakeData(t, strconv.Itoa(int(randPort1)), data1, "id1", nsqd1, fakeLeadership, fakeLookupProxy.(*fakeLookupRemoteProxy))
+	defer os.RemoveAll(data1)
+	defer nsqd1.Exit()
+	defer nsqdCoord1.Stop()
+	time.Sleep(time.Second)
+
+	nsqdCoord2 := startNsqdCoordWithFakeData(t, strconv.Itoa(int(randPort2)), data2, "id2", nsqd2, fakeLeadership, fakeLookupProxy.(*fakeLookupRemoteProxy))
+	defer os.RemoveAll(data2)
+	defer nsqd2.Exit()
+	defer nsqdCoord2.Stop()
+	time.Sleep(time.Second)
+
+	// create topic on nsqdcoord
+	var topicInitInfo RpcAdminTopicInfo
+	topicInitInfo.TopicPartitionMetaInfo = *fakeInfo
+	ensureTopicOnNsqdCoord(nsqdCoord1, topicInitInfo)
+	ensureTopicOnNsqdCoord(nsqdCoord2, topicInitInfo)
+	// notify leadership to nsqdcoord
+	ensureTopicLeaderSession(nsqdCoord1, topic, partition, fakeSession)
+	ensureTopicLeaderSession(nsqdCoord2, topic, partition, fakeSession)
+	ensureTopicDisableWrite(nsqdCoord1, topic, partition, false)
+	ensureTopicDisableWrite(nsqdCoord2, topic, partition, false)
+
+	// message header is 26 bytes
+	msgCnt := 0
+	msgRawSize := int64(nsqdNs.MessageHeaderBytes() + 3 + 4)
+	if meta.Ext {
+		msgRawSize += 1
+	}
+	topicData1 := nsqd1.GetTopic(topic, partition, false)
+	for i := 0; i < 2000; i++ {
+		_, _, _, _, err := nsqdCoord1.PutMessageBodyToCluster(topicData1, []byte("123"), 0)
+		test.Nil(t, err)
+		msgCnt++
+	}
+
+	topicData2 := nsqd2.GetTopic(topic, partition, false)
+	topicData1.ForceFlush()
+	topicData2.ForceFlush()
+
+	tc1, _ := nsqdCoord1.getTopicCoord(topic, partition)
+	logs1, err := tc1.logMgr.GetCommitLogsV2(0, 0, msgCnt)
+	test.Nil(t, err)
+	test.Equal(t, len(logs1), msgCnt)
+
+	test.Equal(t, topicData2.TotalDataSize(), msgRawSize*int64(msgCnt))
+	test.Equal(t, topicData2.TotalMessageCnt(), uint64(msgCnt))
+	tc2, _ := nsqdCoord2.getTopicCoord(topic, partition)
+	logs2, err := tc2.logMgr.GetCommitLogsV2(0, 0, msgCnt)
+	t.Log(logs2)
+	test.Nil(t, err)
+	test.Equal(t, len(logs2), msgCnt)
+	test.Equal(t, logs1, logs2)
+
+	t.Log("====== begin start catchup abort test =============")
+	// start as catchup
+	// and abort by removing catchup
+	nsqdCoord3 := startNsqdCoordWithFakeData(t, strconv.Itoa(int(randPort3)), data3, "id3", nsqd3, fakeLeadership, fakeLookupProxy.(*fakeLookupRemoteProxy))
+	defer os.RemoveAll(data3)
+	defer nsqd3.Exit()
+	defer nsqdCoord3.Stop()
+	ensureTopicOnNsqdCoord(nsqdCoord3, topicInitInfo)
+	ensureTopicLeaderSession(nsqdCoord3, topic, partition, fakeSession)
+
+	tc3, coordErr := nsqdCoord3.getTopicCoord(topic, partition)
+	test.Nil(t, coordErr)
+	test.NotNil(t, tc3)
+
+	atomic.StoreInt32(&testCatchupPausedPullLogs, 1)
+	defer func() {
+		atomic.StoreInt32(&testCatchupPausedPullLogs, 0)
+	}()
+
+	// wait full catchup
+	time.Sleep(time.Second)
+
+	topicInitInfo.Epoch++
+	fakeInfo.CatchupList = make([]string, 0)
+	topicInitInfo.TopicPartitionMetaInfo = *fakeInfo
+	// TODO: get rpc for this node to call UpdateTopicInfo
+	rpcClient, err := NewNsqdRpcClient("127.0.0.1:"+strconv.Itoa(int(randPort3)), time.Second*5)
+	test.Nil(t, err)
+	go func() {
+		coordErr := rpcClient.UpdateTopicInfo(topicInitInfo.Epoch, fakeInfo)
+		test.Nil(t, coordErr)
+	}()
+	//ensureTopicOnNsqdCoord(nsqdCoord3, topicInitInfo)
+	//ensureTopicLeaderSession(nsqdCoord3, topic, partition, fakeSession)
+	time.Sleep(time.Second * 1)
+	atomic.StoreInt32(&testCatchupPausedPullLogs, 0)
+	time.Sleep(time.Second * 2)
+	_, coordErr = nsqdCoord3.getTopicCoord(topic, partition)
+	test.NotNil(t, coordErr)
 }
 
 // catchup from empty
@@ -950,7 +1090,7 @@ func testNsqdCoordCatchupMultiCommitSegment(t *testing.T, meta TopicMetaInfo) {
 	topic := "coordTestTopic"
 	partition := 1
 	if testing.Verbose() {
-		SetCoordLogger(&levellogger.SimpleLogger{}, levellogger.LOG_DETAIL)
+		SetCoordLogger(newTestLogger(t), levellogger.LOG_DETAIL)
 		glog.SetFlags(0, "", "", true, true, 1)
 		glog.StartWorker(time.Second)
 	} else {
@@ -1196,7 +1336,7 @@ func testNsqdCoordCatchupCleanOldData(t *testing.T, meta TopicMetaInfo) {
 	topic := "coordTestTopic"
 	partition := 1
 	if testing.Verbose() {
-		SetCoordLogger(&levellogger.SimpleLogger{}, levellogger.LOG_DETAIL)
+		SetCoordLogger(newTestLogger(t), levellogger.LOG_DETAIL)
 		glog.SetFlags(0, "", "", true, true, 1)
 		glog.StartWorker(time.Second)
 	} else {
@@ -1394,7 +1534,7 @@ func testNsqdCoordPutMessageAndSyncChannelOffset(t *testing.T, isExt bool) {
 	partition := 1
 
 	if testing.Verbose() {
-		SetCoordLogger(&levellogger.SimpleLogger{}, levellogger.LOG_DETAIL)
+		SetCoordLogger(newTestLogger(t), levellogger.LOG_DETAIL)
 		glog.SetFlags(0, "", "", true, true, 1)
 		glog.StartWorker(time.Second)
 	} else {
@@ -1765,13 +1905,7 @@ func benchmarkNsqdCoordPubWithArg(b *testing.B, replica int, size int) {
 	topicBase := "coordBenchTestTopic"
 	partition := 1
 
-	if testing.Verbose() {
-		SetCoordLogger(&levellogger.SimpleLogger{}, levellogger.LOG_WARN)
-		glog.SetFlags(0, "", "", true, true, 1)
-		glog.StartWorker(time.Second)
-	} else {
-		SetCoordLogger(nil, levellogger.LOG_WARN)
-	}
+	SetCoordLogger(nil, levellogger.LOG_WARN)
 
 	nsqd1, randPort1, nodeInfo1, data1 := newNsqdNode(nil, "id1")
 	coordLog.Warningf("data1: %v", data1)

--- a/consistence/nsqd_rpc_client.go
+++ b/consistence/nsqd_rpc_client.go
@@ -2,14 +2,15 @@ package consistence
 
 import (
 	"bytes"
+	"io"
+	"sync"
+	"time"
+
 	"github.com/absolute8511/gorpc"
 	pb "github.com/youzan/nsq/consistence/coordgrpc"
 	"github.com/youzan/nsq/nsqd"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-	"sync"
-	"time"
-	"io"
 )
 
 const (
@@ -349,6 +350,8 @@ func (self *NsqdRpcClient) UpdateChannelOffset(leaderSession *TopicLeaderSession
 		req.TopicData = &rpcData
 		req.Channel = channel
 		req.ChannelOffset.Voffset = offset.VOffset
+		// TODO: VCnt for pb
+		// req.ChannelOffset.VCnt = offset.VCnt
 		req.ChannelOffset.Flush = offset.Flush
 		req.ChannelOffset.AllowBackward = offset.AllowBackward
 

--- a/consistence/nsqlookup_coordinator.go
+++ b/consistence/nsqlookup_coordinator.go
@@ -35,9 +35,9 @@ var (
 )
 
 const (
-	waitMigrateInterval          = time.Minute * 10
-	waitEmergencyMigrateInterval = time.Second * 10
-	waitRemovingNodeInterval     = time.Second * 30
+	waitMigrateInterval          = time.Second * 3
+	waitEmergencyMigrateInterval = time.Second * 1
+	waitRemovingNodeInterval     = time.Second * 3
 )
 
 type JoinISRState struct {

--- a/consistence/nsqlookup_coordinator.go
+++ b/consistence/nsqlookup_coordinator.go
@@ -35,9 +35,9 @@ var (
 )
 
 const (
-	waitMigrateInterval          = time.Second * 3
-	waitEmergencyMigrateInterval = time.Second * 1
-	waitRemovingNodeInterval     = time.Second * 3
+	waitMigrateInterval          = time.Minute * 10
+	waitEmergencyMigrateInterval = time.Second * 10
+	waitRemovingNodeInterval     = time.Second * 30
 )
 
 type JoinISRState struct {

--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -567,7 +567,7 @@ func (c *Channel) exit(deleted bool) error {
 	<-c.exitSyncChan
 
 	// write anything leftover to disk
-	c.flush()
+	c.Flush()
 	if deleted {
 		// empty the queue (deletes the backend files, too)
 		if c.GetDelayedQueue() != nil {
@@ -593,7 +593,7 @@ func (c *Channel) skipChannelToEnd() (BackendQueueEnd, error) {
 	return e, nil
 }
 
-func (c *Channel) flush() error {
+func (c *Channel) Flush() error {
 	if c.ephemeral {
 		return nil
 	}
@@ -775,7 +775,7 @@ func (c *Channel) ConfirmBackendQueueOnSlave(offset BackendOffset, cnt int64, al
 			d, ok := c.backend.(*diskQueueReader)
 			if ok {
 				newConfirmed, err = d.ResetReadToOffset(offset, cnt)
-				nsqLog.LogDebugf("channel (%v) reset to backward: %v", c.GetName(), newConfirmed)
+				nsqLog.LogDebugf("topic %v channel (%v) reset to backward: %v", c.GetTopicName(), c.GetName(), newConfirmed)
 			}
 		}
 	} else {
@@ -783,7 +783,7 @@ func (c *Channel) ConfirmBackendQueueOnSlave(offset BackendOffset, cnt int64, al
 			d, ok := c.backend.(*diskQueueReader)
 			if ok {
 				newConfirmed, err = d.ResetReadToOffset(offset, cnt)
-				nsqLog.LogDebugf("channel (%v) reset to backward: %v", c.GetName(), newConfirmed)
+				nsqLog.LogDebugf("topic %v channel (%v) reset to backward: %v", c.GetTopicName(), c.GetName(), newConfirmed)
 			}
 		} else {
 			_, err = c.backend.SkipReadToOffset(offset, cnt)

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -99,7 +99,9 @@ func New(opts *Options) *NSQD {
 		nsqLog.LogErrorf("failed to create directory: %v ", err)
 		os.Exit(1)
 	}
-	DEFAULT_RETENTION_DAYS = int(opts.RetentionDays)
+	if opts.RetentionSizePerDay > 0 {
+		DEFAULT_RETENTION_DAYS = int(opts.RetentionDays)
+	}
 
 	n := &NSQD{
 		startTime:            time.Now(),

--- a/nsqd/options.go
+++ b/nsqd/options.go
@@ -93,11 +93,13 @@ type Options struct {
 	RemoteTracer string `flag:"remote-tracer"`
 
 	RetentionDays         int32 `flag:"retention-days" cfg:"retention_days"`
-	RetentionSizePerDay         int64 `flag:"retention-size-per-day" cfg:"retention_size_per_day"`
+	RetentionSizePerDay   int64 `flag:"retention-size-per-day" cfg:"retention_size_per_day"`
 	StartAsFixMode        bool  `flag:"start-as-fix-mode"`
 	AllowExtCompatible    bool  `flag:"allow-ext-compatible" cfg:"allow_ext_compatible"`
 	AllowSubExtCompatible bool  `flag:"allow-sub-ext-compatible" cfg:"allow_sub_ext_compatible"`
-	AllowZanTestSkip     bool  `flag:"allow-zan-test-skip"`
+	AllowZanTestSkip      bool  `flag:"allow-zan-test-skip"`
+	DefaultCommitBuf      int32 `flag:"default-commit-buf" cfg:"default_commit_buf"`
+	MaxCommitBuf          int32 `flag:"max-commit-buf" cfg:"max_commit_buf"`
 }
 
 func NewOptions() *Options {

--- a/nsqd/topic.go
+++ b/nsqd/topic.go
@@ -1240,7 +1240,7 @@ func (t *Topic) ForceFlush() {
 	s = time.Now()
 	t.channelLock.RLock()
 	for _, channel := range t.channelMap {
-		channel.flush()
+		channel.Flush()
 	}
 	t.channelLock.RUnlock()
 	cost = time.Now().Sub(s)

--- a/nsqd/topic.go
+++ b/nsqd/topic.go
@@ -80,9 +80,9 @@ type PubInfo struct {
 type PubInfoChan chan *PubInfo
 
 type ChannelMetaInfo struct {
-	Name    string `json:"name"`
-	Paused  bool   `json:"paused"`
-	Skipped bool   `json:"skipped"`
+	Name           string `json:"name"`
+	Paused         bool   `json:"paused"`
+	Skipped        bool   `json:"skipped"`
 	ZanTestSkipped bool   `json:"zanTestSkipped"`
 }
 
@@ -147,11 +147,11 @@ func GetTopicFullName(topic string, part int) string {
 func NewTopic(topicName string, part int, opt *Options,
 	writeDisabled int32,
 	notify INsqdNotify, loopFunc func(v *Topic)) *Topic {
-	return NewTopicWithExt(topicName, part, false, opt, writeDisabled, notify, loopFunc)
+	return NewTopicWithExt(topicName, part, false, false, opt, writeDisabled, notify, loopFunc)
 }
 
 // Topic constructor
-func NewTopicWithExt(topicName string, part int, ext bool, opt *Options,
+func NewTopicWithExt(topicName string, part int, ext bool, ordered bool, opt *Options,
 	writeDisabled int32,
 	notify INsqdNotify, loopFunc func(v *Topic)) *Topic {
 	if part > MAX_TOPIC_PARTITION {
@@ -173,6 +173,9 @@ func NewTopicWithExt(topicName string, part int, ext bool, opt *Options,
 	}
 	if ext {
 		t.setExt()
+	}
+	if ordered {
+		atomic.StoreInt32(&t.isOrdered, 1)
 	}
 	if t.dynamicConf.SyncEvery < 1 {
 		t.dynamicConf.SyncEvery = 1
@@ -444,7 +447,7 @@ func (t *Topic) LoadChannelMeta() error {
 		//skip zan test message according to meta file
 		if ch.IsZanTestSkipepd() {
 			channel.SkipZanTest()
-		}//else nothing maybe unskip
+		} //else nothing maybe unskip
 	}
 	return nil
 }
@@ -456,9 +459,9 @@ func (t *Topic) GetChannelMeta() []ChannelMetaInfo {
 		channel.RLock()
 		if !channel.ephemeral {
 			meta := ChannelMetaInfo{
-				Name:    channel.name,
-				Paused:  channel.IsPaused(),
-				Skipped: channel.IsSkipped(),
+				Name:           channel.name,
+				Paused:         channel.IsPaused(),
+				Skipped:        channel.IsSkipped(),
 				ZanTestSkipped: channel.IsZanTestSkipped(),
 			}
 			channels = append(channels, meta)
@@ -477,9 +480,9 @@ func (t *Topic) SaveChannelMeta() error {
 		channel.RLock()
 		if !channel.ephemeral {
 			meta := &ChannelMetaInfo{
-				Name:    channel.name,
-				Paused:  channel.IsPaused(),
-				Skipped: channel.IsSkipped(),
+				Name:           channel.name,
+				Paused:         channel.IsPaused(),
+				Skipped:        channel.IsSkipped(),
 				ZanTestSkipped: channel.IsZanTestSkipped(),
 			}
 			channels = append(channels, meta)
@@ -731,7 +734,7 @@ func (t *Topic) getOrCreateChannel(channelName string) (*Channel, bool) {
 			ext = 0
 		}
 		start := t.backend.GetQueueReadStart()
-		channel = NewChannel(t.GetTopicName(), t.GetTopicPart(), channelName, readEnd,
+		channel = NewChannel(t.GetTopicName(), t.GetTopicPart(), t.IsOrdered(), channelName, readEnd,
 			t.option, deleteCallback, t.flushForChannelMoreData, atomic.LoadInt32(&t.writeDisabled),
 			t.nsqdNotify, ext, start)
 

--- a/nsqd/topic_test.go
+++ b/nsqd/topic_test.go
@@ -21,14 +21,14 @@ func TestGetTopic(t *testing.T) {
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	topic1 := nsqd.GetTopic("test", 0)
+	topic1 := nsqd.GetTopic("test", 0, false)
 	test.NotNil(t, topic1)
 	test.Equal(t, "test", topic1.GetTopicName())
 
-	topic2 := nsqd.GetTopic("test", 0)
+	topic2 := nsqd.GetTopic("test", 0, false)
 	test.Equal(t, topic1, topic2)
 
-	topic3 := nsqd.GetTopic("test2", 1)
+	topic3 := nsqd.GetTopic("test2", 1, false)
 	test.Equal(t, "test2", topic3.GetTopicName())
 	test.NotEqual(t, topic2, topic3)
 
@@ -48,7 +48,7 @@ func TestGetChannel(t *testing.T) {
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	topic := nsqd.GetTopic("test", 0)
+	topic := nsqd.GetTopic("test", 0, false)
 
 	channel1 := topic.GetChannel("ch1")
 	test.NotNil(t, channel1)
@@ -89,7 +89,7 @@ func TestTopicMarkRemoved(t *testing.T) {
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	topic := nsqd.GetTopic("test", 0)
+	topic := nsqd.GetTopic("test", 0, false)
 	origPath := topic.dataPath
 
 	channel1 := topic.GetChannel("ch1")
@@ -99,7 +99,7 @@ func TestTopicMarkRemoved(t *testing.T) {
 		msg.ID = 0
 		topic.PutMessage(msg)
 	}
-	topic1 := nsqd.GetTopic("test", 1)
+	topic1 := nsqd.GetTopic("test", 1, false)
 	err := topic.SetMagicCode(time.Now().UnixNano())
 	err = topic1.SetMagicCode(time.Now().UnixNano())
 	test.Equal(t, nil, err)
@@ -207,7 +207,7 @@ func TestDeleteLast(t *testing.T) {
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	topic := nsqd.GetTopic("test", 0)
+	topic := nsqd.GetTopic("test", 0, false)
 
 	channel1 := topic.GetChannel("ch1")
 	test.NotNil(t, channel1)
@@ -230,7 +230,7 @@ func TestTopicBackendMaxMsgSize(t *testing.T) {
 	defer nsqd.Exit()
 
 	topicName := "test_topic_backend_maxmsgsize" + strconv.Itoa(int(time.Now().Unix()))
-	topic := nsqd.GetTopic(topicName, 0)
+	topic := nsqd.GetTopic(topicName, 0, false)
 
 	test.Equal(t, topic.backend.maxMsgSize, int32(opts.MaxMsgSize+minValidMsgLength))
 }
@@ -242,7 +242,7 @@ func TestTopicPutChannelWait(t *testing.T) {
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	topic := nsqd.GetTopic("test", 0)
+	topic := nsqd.GetTopic("test", 0, false)
 	topic.dynamicConf.AutoCommit = 1
 	topic.dynamicConf.SyncEvery = 10
 
@@ -299,7 +299,7 @@ func TestTopicCleanOldDataByRetentionSize(t *testing.T) {
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	topic := nsqd.GetTopic("test", 0)
+	topic := nsqd.GetTopic("test", 0, false)
 	topic.dynamicConf.AutoCommit = 1
 	topic.dynamicConf.SyncEvery = 10
 	topic.dynamicConf.RetentionDay = 1
@@ -372,7 +372,7 @@ func TestTopicCleanOldDataByRetentionDay(t *testing.T) {
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	topic := nsqd.GetTopic("test", 0)
+	topic := nsqd.GetTopic("test", 0, false)
 	topic.dynamicConf.AutoCommit = 1
 	topic.dynamicConf.SyncEvery = 10
 
@@ -456,7 +456,7 @@ func TestTopicCleanOldDataByRetentionDayWithResetStart(t *testing.T) {
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	topic := nsqd.GetTopic("test", 0)
+	topic := nsqd.GetTopic("test", 0, false)
 	topic.dynamicConf.AutoCommit = 1
 	topic.dynamicConf.SyncEvery = 10
 
@@ -527,7 +527,7 @@ func TestTopicResetWithQueueStart(t *testing.T) {
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
 
-	topic := nsqd.GetTopic("test", 0)
+	topic := nsqd.GetTopic("test", 0, false)
 	topic.dynamicConf.AutoCommit = 1
 	topic.dynamicConf.SyncEvery = 10
 
@@ -634,7 +634,7 @@ func benchmarkTopicPut(b *testing.B, size int) {
 	b.StartTimer()
 
 	for i := 0; i <= b.N; i++ {
-		topic := nsqd.GetTopic(topicName, 0)
+		topic := nsqd.GetTopic(topicName, 0, false)
 		msg.ID = 0
 		topic.PutMessage(msg)
 	}
@@ -659,12 +659,12 @@ func BenchmarkTopicToChannelPut(b *testing.B) {
 	_, _, nsqd := mustStartNSQD(opts)
 	defer os.RemoveAll(opts.DataPath)
 	defer nsqd.Exit()
-	nsqd.GetTopic(topicName, 0).GetChannel(channelName)
+	nsqd.GetTopic(topicName, 0, false).GetChannel(channelName)
 	b.StartTimer()
 	msg := NewMessage(0, []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaa"))
 
 	for i := 0; i <= b.N; i++ {
-		topic := nsqd.GetTopic(topicName, 0)
+		topic := nsqd.GetTopic(topicName, 0, false)
 		msg.ID = 0
 		topic.PutMessage(msg)
 	}

--- a/nsqdserver/context.go
+++ b/nsqdserver/context.go
@@ -102,11 +102,11 @@ func (c *context) getExistingTopic(name string, part int) (*nsqd.Topic, error) {
 	return c.nsqd.GetExistingTopic(name, part)
 }
 
-func (c *context) getTopic(name string, part int, ext bool) *nsqd.Topic {
+func (c *context) getTopic(name string, part int, ext bool, ordered bool) *nsqd.Topic {
 	if ext {
-		return c.nsqd.GetTopicWithExt(name, part)
+		return c.nsqd.GetTopicWithExt(name, part, ordered)
 	} else {
-		return c.nsqd.GetTopic(name, part)
+		return c.nsqd.GetTopic(name, part, ordered)
 	}
 }
 

--- a/nsqdserver/http_test.go
+++ b/nsqdserver/http_test.go
@@ -900,7 +900,7 @@ func BenchmarkHTTPpub(b *testing.B) {
 	topicName := "bench_http_pub" + strconv.Itoa(int(time.Now().Unix()))
 	url := fmt.Sprintf("http://%s/pub?topic=%s", httpAddr, topicName)
 	client := &http.Client{}
-	nsqdData.GetTopic(topicName, 0)
+	nsqdData.GetTopic(topicName, 0, false)
 	b.SetBytes(int64(len(msg)))
 	b.StartTimer()
 
@@ -1052,11 +1052,11 @@ func TestNSQDStatsFilter(t *testing.T) {
 	}
 	t.Logf("%d topic(s) deleted.", topicCnt)
 	topicName := fmt.Sprintf("test_nsqd_stats_filter%d", time.Now().UnixNano())
-	nsqd.GetTopic(topicName, 0)
+	nsqd.GetTopic(topicName, 0, false)
 	defer nsqd.DeleteExistingTopic(topicName, 0)
 
 	topicNameAnother := fmt.Sprintf("test_nsqd_stats_filter_another%d", time.Now().UnixNano())
-	nsqd.GetTopic(topicNameAnother, 0)
+	nsqd.GetTopic(topicNameAnother, 0, false)
 	topic_another, err := nsqd.GetExistingTopic(topicNameAnother, 0)
 	topic_another.DisableForSlave()
 	defer nsqd.DeleteExistingTopic(topicNameAnother, 0)
@@ -1117,7 +1117,7 @@ func BenchmarkFetchNodeHourlyPubsize(b *testing.B) {
 	for i := 0; i < 1000; i++ {
 		//create sample topics
 		topicName := fmt.Sprintf("Topic-Benchmark%04d", i)
-		nsqd1.GetTopic(topicName, 0)
+		nsqd1.GetTopic(topicName, 0, false)
 		topicNames = append(topicNames, topicName)
 		b.Logf("Topic %s created.", topicName)
 	}

--- a/nsqdserver/nsqd_server.go
+++ b/nsqdserver/nsqd_server.go
@@ -88,6 +88,13 @@ func NewNsqdServer(opts *nsqd.Options) (*nsqd.NSQD, *NsqdServer) {
 		nsqd.NsqLogger().LogWarningf("starting in data fix mode...")
 	}
 
+	if opts.DefaultCommitBuf > 0 {
+		consistence.DEFAULT_COMMIT_BUF_SIZE = opts.DefaultCommitBuf
+	}
+	if opts.MaxCommitBuf > 0 {
+		consistence.MAX_COMMIT_BUF_SIZE = opts.MaxCommitBuf
+	}
+
 	nsqdInstance := nsqd.New(opts)
 
 	s := &NsqdServer{}

--- a/nsqdserver/nsqd_server.go
+++ b/nsqdserver/nsqd_server.go
@@ -89,10 +89,10 @@ func NewNsqdServer(opts *nsqd.Options) (*nsqd.NSQD, *NsqdServer) {
 	}
 
 	if opts.DefaultCommitBuf > 0 {
-		consistence.DEFAULT_COMMIT_BUF_SIZE = opts.DefaultCommitBuf
+		consistence.DEFAULT_COMMIT_BUF_SIZE = int(opts.DefaultCommitBuf)
 	}
 	if opts.MaxCommitBuf > 0 {
-		consistence.MAX_COMMIT_BUF_SIZE = opts.MaxCommitBuf
+		consistence.MAX_COMMIT_BUF_SIZE = int(opts.MaxCommitBuf)
 	}
 
 	nsqdInstance := nsqd.New(opts)

--- a/nsqdserver/protocol_v2.go
+++ b/nsqdserver/protocol_v2.go
@@ -1276,7 +1276,7 @@ func (p *protocolV2) internalCreateTopic(client *nsqd.ClientV2, params [][]byte)
 			fmt.Sprintf("CREATE_TOPIC is not allowed here while cluster feature enabled."))
 	}
 
-	topic := p.ctx.getTopic(topicName, partition, ext)
+	topic := p.ctx.getTopic(topicName, partition, ext, false)
 	if topic == nil {
 		return nil, protocol.NewClientErr(err, "E_CREATE_TOPIC_FAILED",
 			fmt.Sprintf("CREATE_TOPIC %v failed", topicName))

--- a/nsqdserver/protocol_v2_test.go
+++ b/nsqdserver/protocol_v2_test.go
@@ -2540,21 +2540,21 @@ func TestTcpMpubExt(t *testing.T) {
 	test.Equal(t, err, nil)
 
 	topicName := "test_tcp_mpub_ext" + strconv.Itoa(int(time.Now().Unix()))
-	nsqd.GetTopicWithExt(topicName, 0).GetChannel("ch")
+	nsqd.GetTopicWithExt(topicName, 0, false).GetChannel("ch")
 
 	identify(t, conn, nil, frameTypeResponse)
 	var msgExtList []*nsq.MsgExt
 	var msgBody [][]byte
 	// PUB ext to non-ext topic
 	for i := 0; i < 10; i++ {
-		if i%2==0 {
+		if i%2 == 0 {
 			msgExtList = append(msgExtList, &nsq.MsgExt{})
 			msgBody = append(msgBody, []byte("msg has no ext"))
 		} else {
 			msgExtList = append(msgExtList, &nsq.MsgExt{
-				TraceID: 123,
+				TraceID:     123,
 				DispatchTag: "desiredTag",
-				Custom: map[string]string{"key1":"val1", "key2":"val2"},
+				Custom:      map[string]string{"key1": "val1", "key2": "val2"},
 			})
 			msgBody = append(msgBody, []byte("msg has ext"))
 		}
@@ -2572,7 +2572,7 @@ func TestTcpMpubExt(t *testing.T) {
 	conn.Close()
 
 	conn, err = mustConnectNSQD(tcpAddr)
-	identify(t, conn, map[string]interface{}{"extend_support":true}, frameTypeResponse)
+	identify(t, conn, map[string]interface{}{"extend_support": true}, frameTypeResponse)
 	test.Equal(t, err, nil)
 	sub(t, conn, topicName, "ch")
 	_, err = nsq.Ready(1).WriteTo(conn)
@@ -3468,23 +3468,23 @@ func TestZanTestSkip(t *testing.T) {
 
 	//send messages, zan_test and normal combined
 	topicName := "test_zan_test_skip" + strconv.Itoa(int(time.Now().Unix()))
-	ch := nsqd.GetTopicWithExt(topicName, 0).GetChannel("ch")
+	ch := nsqd.GetTopicWithExt(topicName, 0, false).GetChannel("ch")
 
 	identify(t, conn, nil, frameTypeResponse)
 	var msgExtList []*nsq.MsgExt
 	var msgBody [][]byte
 	// PUB ext to non-ext topic
 	for i := 0; i < 10; i++ {
-		if i%2==0 {
+		if i%2 == 0 {
 			msgExtList = append(msgExtList, &nsq.MsgExt{
-				Custom: map[string]string{"key1":"val1", "key2":"val2"},
+				Custom: map[string]string{"key1": "val1", "key2": "val2"},
 			})
 			msgBody = append(msgBody, []byte("msg has no zan_test ext"))
 		} else {
 			msgExtList = append(msgExtList, &nsq.MsgExt{
-				TraceID: 123,
+				TraceID:     123,
 				DispatchTag: "desiredTag",
-				Custom: map[string]string{"zan_test":"true", "key1":"val1"},
+				Custom:      map[string]string{"zan_test": "true", "key1": "val1"},
 			})
 			msgBody = append(msgBody, []byte("msg has zan_test ext"))
 		}
@@ -3505,7 +3505,7 @@ func TestZanTestSkip(t *testing.T) {
 	ch.SkipZanTest()
 	//consume&validate zan_test messages
 	conn, err = mustConnectNSQD(tcpAddr)
-	identify(t, conn, map[string]interface{}{"extend_support":true}, frameTypeResponse)
+	identify(t, conn, map[string]interface{}{"extend_support": true}, frameTypeResponse)
 	test.Equal(t, err, nil)
 	sub(t, conn, topicName, "ch")
 	_, err = nsq.Ready(10).WriteTo(conn)
@@ -5848,7 +5848,7 @@ func benchmarkProtocolV2PubWithArg(b *testing.B, size int, single bool) {
 		batch[i] = msg
 	}
 	topicName := "bench_v2_pub" + strconv.Itoa(int(time.Now().Unix()))
-	testTopic := nsqd.GetTopic(topicName, 0)
+	testTopic := nsqd.GetTopic(topicName, 0, false)
 
 	b.SetBytes(int64(len(msg)))
 	b.StartTimer()

--- a/nsqlookupd/http.go
+++ b/nsqlookupd/http.go
@@ -367,7 +367,7 @@ func (s *httpServer) doLookup(w http.ResponseWriter, req *http.Request, ps httpr
 				}
 			}
 			if len(registrations) > 0 {
-				nsqlookupLog.Logf("no topic producers found in memory, found in cluster: %v, %v", len(clusterNodes), len(registrations))
+				nsqlookupLog.Logf("no topic %v producers found in memory, found in cluster: %v, %v", topicName, len(clusterNodes), len(registrations))
 			}
 		}
 	}


### PR DESCRIPTION
1. fix concurrent topic delete while catchup  sync from the leader
2. sync channel offset from leader while catchup
3. add a config to change the default commit buffer size.
4. make sure etcd watch and get will return newest data.
5. channel memory usage optimize.
6. channel handle requeued message first.