### PR TITLE
fix log format

### DIFF
--- a/nsqd/diskqueue_reader.go
+++ b/nsqd/diskqueue_reader.go
@@ -1033,10 +1033,10 @@ CheckFileOpen:
 		if err == nil {
 			// we compare the meta file to check if any wrong on the count of message
 			if metaEnd != int64(d.readQueueInfo.Offset()) {
-				nsqLog.Warningf("the reader offset is not equal with the meta. %v", d.readQueueInfo, metaEnd)
+				nsqLog.Warningf("the reader offset is not equal with the meta. %v %d", d.readQueueInfo, metaEnd)
 			} else {
 				if fixCnt != d.readQueueInfo.TotalMsgCnt() {
-					nsqLog.Warningf("the reader offset is not equal with the meta. %v", d.readQueueInfo, fixCnt)
+					nsqLog.Warningf("the reader offset is not equal with the meta. %v %d", d.readQueueInfo, fixCnt)
 				}
 			}
 		}

--- a/nsqd/nsqd.go
+++ b/nsqd/nsqd.go
@@ -969,7 +969,7 @@ func (n *NSQD) PushTopicJob(t *Topic, job func()) {
 		default:
 		}
 	}
-	nsqLog.Logf("%v topic job push ignored: %v", t.GetFullName(), job)
+	nsqLog.Logf("%v topic job push ignored: %T", t.GetFullName(), job)
 }
 
 func doJob(job func()) {


### PR DESCRIPTION
```
# github.com/youzan/nsq/nsqd
nsqd/diskqueue_reader.go:1036: Warningf call needs 1 arg but has 2 args
nsqd/diskqueue_reader.go:1039: Warningf call needs 1 arg but has 2 args
nsqd/nsqd.go:972: Logf format %v arg job is a func value, not called
FAIL    github.com/youzan/nsq/nsqd [build failed]
```

failed when run test.sh