### PR TITLE
修改闭包中使用变量问题，导致web ui中显示连接的lookupd节点都是同一个值

### DIFF
--- a/internal/clusterinfo/data.go
+++ b/internal/clusterinfo/data.go
@@ -309,7 +309,7 @@ func (c *ClusterInfo) GetLookupdProducers(lookupdHTTPAddrs []LookupdAddressDC) (
 					p = producer
 				}
 				p.RemoteAddresses = append(p.RemoteAddresses,
-					fmt.Sprintf("%s/%s", addr, producer.Address()))
+					fmt.Sprintf("%s/%s", lookupd, producer.Address()))
 			}
 		}(lookupd)
 	}


### PR DESCRIPTION
nsqadmin获取界面显示Lookupd Conns状态时，由于错误使用变量，导致在有多个lookupd节点时，该连接状态显示的连接节点信息有误，显示的值都是最后addr的求值结果。
