### PR TITLE
print the cost-time in the trace log

### DIFF
--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -1992,7 +1992,7 @@ LOOP:
 				}
 				if resumedFirst {
 					if nsqLog.Level() > levellogger.LOG_DEBUG || c.IsTraced() {
-						nsqLog.LogDebugf("channel %v resumed first messsage %v at Offset: %v", c.GetName(), msg.ID, msg.Offset)
+						nsqLog.LogDebugf("channel %v resumed first message %v at Offset: %v", c.GetName(), msg.ID, msg.Offset)
 					}
 					resumedFirst = false
 				}
@@ -2493,7 +2493,7 @@ func (c *Channel) peekAndReqDelayedMessages(tnow int64, delayedQueue *DelayQueue
 						c.GetName(), tnow, m)
 				}
 
-				nsqMsgTracer.TraceSub(c.GetTopicName(), c.GetName(), "DELAY_QUEUE_TIMEOUT", m.TraceID, &m, "", time.Now().UnixNano() - m.Timestamp)
+				nsqMsgTracer.TraceSub(c.GetTopicName(), c.GetName(), "DELAY_QUEUE_TIMEOUT", m.TraceID, &m, "", tnow - m.Timestamp)
 
 				newAdded++
 				if m.belongedConsumer != nil {

--- a/nsqd/channel.go
+++ b/nsqd/channel.go
@@ -1914,7 +1914,7 @@ LOOP:
 		case msg = <-c.requeuedMsgChan:
 			if msg.TraceID != 0 || c.IsTraced() || nsqLog.Level() >= levellogger.LOG_DETAIL {
 				nsqLog.LogDebugf("read message %v from requeue", msg.ID)
-				nsqMsgTracer.TraceSub(c.GetTopicName(), c.GetName(), "READ_REQ", msg.TraceID, msg, "0", 0)
+				nsqMsgTracer.TraceSub(c.GetTopicName(), c.GetName(), "READ_REQ", msg.TraceID, msg, "0", time.Now().UnixNano() - msg.Timestamp)
 			}
 		default:
 			select {
@@ -1923,7 +1923,7 @@ LOOP:
 			case msg = <-c.requeuedMsgChan:
 				if msg.TraceID != 0 || c.IsTraced() || nsqLog.Level() >= levellogger.LOG_DETAIL {
 					nsqLog.LogDebugf("read message %v from requeue", msg.ID)
-					nsqMsgTracer.TraceSub(c.GetTopicName(), c.GetName(), "READ_REQ", msg.TraceID, msg, "0", 0)
+					nsqMsgTracer.TraceSub(c.GetTopicName(), c.GetName(), "READ_REQ", msg.TraceID, msg, "0", time.Now().UnixNano() - msg.Timestamp)
 				}
 			case data = <-readChan:
 				lastDataNeedRead = false
@@ -1966,7 +1966,7 @@ LOOP:
 				msg.RawMoveSize = data.MovedSize
 				msg.queueCntIndex = data.CurCnt
 				if msg.TraceID != 0 || c.IsTraced() || nsqLog.Level() >= levellogger.LOG_DETAIL {
-					nsqMsgTracer.TraceSub(c.GetTopicName(), c.GetName(), "READ_QUEUE", msg.TraceID, msg, "0", 0)
+					nsqMsgTracer.TraceSub(c.GetTopicName(), c.GetName(), "READ_QUEUE", msg.TraceID, msg, "0", time.Now().UnixNano() - msg.Timestamp)
 				}
 
 				if lastMsg.ID > 0 && msg.ID < lastMsg.ID {
@@ -2493,7 +2493,7 @@ func (c *Channel) peekAndReqDelayedMessages(tnow int64, delayedQueue *DelayQueue
 						c.GetName(), tnow, m)
 				}
 
-				nsqMsgTracer.TraceSub(c.GetTopicName(), c.GetName(), "DELAY_QUEUE_TIMEOUT", m.TraceID, &m, "", 0)
+				nsqMsgTracer.TraceSub(c.GetTopicName(), c.GetName(), "DELAY_QUEUE_TIMEOUT", m.TraceID, &m, "", time.Now().UnixNano() - m.Timestamp)
 
 				newAdded++
 				if m.belongedConsumer != nil {

--- a/nsqd/diskqueue_writer.go
+++ b/nsqd/diskqueue_writer.go
@@ -800,7 +800,7 @@ func (d *diskQueueWriter) writeOne(data []byte, isRaw bool, msgCnt int32) (Backe
 				d.writeFile.Close()
 				d.writeFile = nil
 			}
-			nsqLog.Logf("DISKQUEUE(%s): writeOne() faled %s", d.name, err)
+			nsqLog.Logf("DISKQUEUE(%s): writeOne() failed %s", d.name, err)
 			return 0, 0, nil, err
 		}
 	}
@@ -811,7 +811,7 @@ func (d *diskQueueWriter) writeOne(data []byte, isRaw bool, msgCnt int32) (Backe
 			d.writeFile.Close()
 			d.writeFile = nil
 		}
-		nsqLog.Logf("DISKQUEUE(%s): writeOne() faled %s", d.name, err)
+		nsqLog.Logf("DISKQUEUE(%s): writeOne() failed %s", d.name, err)
 		return 0, 0, nil, err
 	}
 


### PR DESCRIPTION
1.correct word typos in code
2.As cost-time is helpful for message tracing, now print the cost-time in the trace log